### PR TITLE
Add --adb switch to opt out from auto connecting device to local adb

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ COMMANDS
 ENVIRONMENT VARIABLES
     STF_TOKEN - Authorization token 
     STF_URL   - URL to STF 
+
+COMMAND OPTIONS
+    connect
+        -f          - Filter devices in the form of "key:value". Use stf-client keys to list keys and stf-client values -k <key from prev command> to get list of applicable values
+        -d, --adb   - Automatically execute adb connect command once device acquired. Default true
 ```
 
 ## Contributing

--- a/lib/stf/client.rb
+++ b/lib/stf/client.rb
@@ -46,12 +46,12 @@ module Stf
     end
 
     def start_debug(serial)
-      response = execute "/api/v1//user/devices/#{serial}/remoteConnect", Net::HTTP::Post
+      response = execute "/api/v1/user/devices/#{serial}/remoteConnect", Net::HTTP::Post
       return response
     end
 
     def stop_debug(serial)
-      response = execute "/api/v1//user/devices/#{serial}/remoteConnect", Net::HTTP::Delete
+      response = execute "/api/v1/user/devices/#{serial}/remoteConnect", Net::HTTP::Delete
       return response.success
     end
 

--- a/lib/stf/interactor/start_debug_session_interactor.rb
+++ b/lib/stf/interactor/start_debug_session_interactor.rb
@@ -66,7 +66,7 @@ class StartDebugSessionInteractor
     n
   end
 
-  def connect_device(device, auto_adb_connect = true)
+  def connect_device(device, auto_adb_connect)
     begin
       return false if device.nil?
 
@@ -85,10 +85,10 @@ class StartDebugSessionInteractor
         return false
       end
 
+      logger.info "remoteConnectUrl: #{result.remoteConnectUrl}" 
+
       if auto_adb_connect
         _execute_adb_with 30, "connect #{result.remoteConnectUrl}"
-      else
-        logger.info "remoteConnectUrl: #{result.remoteConnectUrl}"
       end
       return true
 

--- a/lib/stf/version.rb
+++ b/lib/stf/version.rb
@@ -1,3 +1,3 @@
 module Stf
-  VERSION = '0.1.6'
+  VERSION = '0.1.7'
 end

--- a/lib/stf/view/cli.rb
+++ b/lib/stf/view/cli.rb
@@ -42,7 +42,7 @@ module Stf
       c.switch [:all]
       c.flag [:n, :number]
       c.flag [:f, :filter]
-      c.switch [:d, :adb, default_value: true, desc: 'automatically execute adb connect']
+      c.switch :adb, default_value: true, desc: 'automatically execute adb connect'
 
       c.action do |global_options, options, args|
         StartDebugSessionInteractor.new($stf).execute(options[:number], options[:all], options[:filter], options[:adb])

--- a/lib/stf/view/cli.rb
+++ b/lib/stf/view/cli.rb
@@ -42,13 +42,14 @@ module Stf
       c.switch [:all]
       c.flag [:n, :number]
       c.flag [:f, :filter]
+      c.switch [:d, :adb, default_value: true, desc: 'automatically execute adb connect']
 
       c.action do |global_options, options, args|
-        StartDebugSessionInteractor.new($stf).execute(options[:number], options[:all], options[:filter])
+        StartDebugSessionInteractor.new($stf).execute(options[:number], options[:all], options[:filter], options[:adb])
       end
     end
 
-    desc 'Show avaliable keys for filtering'
+    desc 'Show available keys for filtering'
     command :keys do |c|
       c.action do |global_options, options, args|
         puts GetKeysInteractor.new($stf).execute

--- a/spec/lib/start_debug_session_interactor_spec.rb
+++ b/spec/lib/start_debug_session_interactor_spec.rb
@@ -1,0 +1,21 @@
+require File.dirname(__FILE__) + '/../spec_helper'
+require 'stf/client'
+require 'stf/interactor/start_debug_session_interactor'
+
+describe StartDebugSessionInteractor do
+  before :each do
+    @stf = Stf::Client.new('http://openstf.io', FakeSTF.fake_token)
+  end
+
+  it 'should execute adb connect ' do
+    session = StartDebugSessionInteractor.new(@stf)
+    expect(session).to receive(:_execute_adb_with)
+    session.execute(1, false, 'serial:UDKDU15A20001021', true)
+  end
+
+  it 'should not execute adb connect ' do
+    session = StartDebugSessionInteractor.new(@stf)
+    expect(session).to_not receive(:_execute_adb_with)
+    session.execute(1, false, 'serial:UDKDU15A20001021', false)
+  end
+end


### PR DESCRIPTION
In my use case, jenkins pipeline, I would like prepare the test device in one stage and use it for testing on another stage.

It's very useful if we want to use docker and the image cannot cater all dependencies, eg: adb and ruby.

Usage:
`stf-client connect --no-adb -f k:v`

It also fixes 'Error 404' that keeps on showing (and make the cli return non-success status to shell) even though we were able to get the device.