### PR TITLE
Downgrade dependencies for use with Ruby 2.3

### DIFF
--- a/stf-client.gemspec
+++ b/stf-client.gemspec
@@ -19,15 +19,17 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'ADB', '~> 0.5'
   spec.add_runtime_dependency 'dante', '~> 0.2.0'
   spec.add_runtime_dependency 'dry-container', '~> 0.6.0'
+  spec.add_runtime_dependency 'dry-configurable', '~> 0.8.3'
 
   # spec.add_runtime_dependency 'pry', '~> 0.10.4'
 
-  spec.add_development_dependency 'bundler', '~> 1.16.a'
+  spec.add_development_dependency 'bundler', '~> 1.13.2'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.5'
   spec.add_development_dependency 'rspec_junit_formatter', '~> 0.2'
   spec.add_development_dependency 'webmock', '~> 2.1'
   spec.add_development_dependency 'sinatra', '~> 1.4'
-  spec.add_development_dependency 'simplecov', '~> 0.14'
+  spec.add_development_dependency 'simplecov', '~> 0.9.1'
   spec.add_development_dependency 'simplecov-json', '~> 0.2'
+  spec.add_development_dependency 'simplecov-html', '~> 0.8.0'
 end

--- a/stf-client.gemspec
+++ b/stf-client.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'dante', '~> 0.2.0'
   spec.add_runtime_dependency 'dry-container', '~> 0.6.0'
   spec.add_runtime_dependency 'dry-configurable', '~> 0.8.3'
+  spec.add_runtime_dependency 'childprocess', '~> 3.0.0'
 
   # spec.add_runtime_dependency 'pry', '~> 0.10.4'
 


### PR DESCRIPTION
The dependencies pulled, require the use of Ruby 2.4. With this PR, the dependencies used, lower the minimum Ruby version to 2.3.