### PR TITLE
Allow regex and string in filter

### DIFF
--- a/lib/stf/model/device.rb
+++ b/lib/stf/model/device.rb
@@ -37,7 +37,7 @@ module Stf
     def checkFilter?(filter)
       return true if filter.nil?
       key, value = filter.split(':', 2)
-      getValue(key) == value
+      !/#{value}/.match(getValue(key)).nil?
     end
 
     def getKeysNextLevel(prefix, o)


### PR DESCRIPTION
Allow regex in filter

Example:

`stf-client connect --min=1 --starttime=300 --all  -f provider.name:"example_node_1"` - connect all devices with provider name example_node_1
`stf-client connect --min=1 --starttime=300 --all  -f provider.name:"example_node_*"`  - connect all devices with provider name contains by regex example_node_* (example_node_1, example_node_234252, example_node_tjwkdhgksd)

